### PR TITLE
Fix building on OS X 10.9 Maverics (clang-500.2.79) with Homebrew

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -363,7 +363,7 @@ function build_gcc {
   pushd "${BUILD_DIR}"
   mkdir_empty "${GCC}"
   cd "${GCC}"
-  "${SOURCES}/${GCC}/configure" \
+  CC="${CC} -std=gnu89" "${SOURCES}/${GCC}/configure" \
     --prefix="${PREFIX}" \
     --target="m68k-amigaos" \
     --enable-languages=c \
@@ -384,7 +384,7 @@ function build_gpp {
   pushd "${BUILD_DIR}"
   mkdir_empty "${GPP}"
   cd "${GPP}"
-  "${SOURCES}/${GCC}/configure" \
+  CC="${CC} -std=gnu89" "${SOURCES}/${GCC}/configure" \
     --prefix="${PREFIX}" \
     --target="m68k-amigaos" \
     --enable-languages=c++ \
@@ -466,7 +466,7 @@ function build_libnix {
     --prefix="${PREFIX}" \
     --host="i686-linux-gnu" \
     --target="m68k-amigaos"
-  make all \
+  ${MAKE} all \
     CC=m68k-amigaos-gcc \
     CPP="m68k-amigaos-gcc -E" \
     AR=m68k-amigaos-ar \

--- a/patches/binutils-2.9.1/include/libiberty.h.diff
+++ b/patches/binutils-2.9.1/include/libiberty.h.diff
@@ -9,4 +9,16 @@
 +
  /* Build an argument vector from a string.  Allocates memory using
     malloc.  Use freeargv to free the vector.  */
+
+@@ -111,12 +111,7 @@
+ 
+ /* Exit, calling all the functions registered with xatexit.  */
+ 
+-#ifndef __GNUC__
+-extern void xexit PARAMS ((int status));
+-#else
+-typedef void libiberty_voidfn PARAMS ((int status));
+-__volatile__ libiberty_voidfn xexit;
+-#endif
++extern void xexit PARAMS ((int status)) __attribute__ ((__noreturn__));
  

--- a/patches/binutils-2.9.1/ld/ldmisc.h.diff
+++ b/patches/binutils-2.9.1/ld/ldmisc.h.diff
@@ -1,0 +1,11 @@
+--- binutils-2.9.1/ld/ldmisc.h	1998-05-01 17:48:49.000000000 +0200
++++ binutils-2.9.1/ld/ldmisc.h	2014-02-20 21:22:30.000000000 +0100
+@@ -40,7 +40,7 @@
+ extern void yyerror PARAMS ((const char *));
+ extern PTR xmalloc PARAMS ((size_t));
+ extern PTR xrealloc PARAMS ((PTR, size_t));
+-extern void xexit PARAMS ((int));
++extern void xexit PARAMS ((int status)) __attribute__ ((__noreturn__));
+ extern char *buystring PARAMS ((CONST char *CONST));
+ 
+ #define ASSERT(x) \

--- a/patches/fd2sfd-1.0/Makefile.in.diff
+++ b/patches/fd2sfd-1.0/Makefile.in.diff
@@ -1,9 +1,14 @@
---- fd2sfd-1.0/Makefile.in.orig	2014-01-02 21:21:41.000000000 +0100
-+++ fd2sfd-1.0/Makefile.in	2014-01-02 21:23:12.000000000 +0100
-@@ -45,45 +45,6 @@
- 	  $(INSTALL_DATA) -D $(srcdir)/cross/share/$${f} $(fd2sfddir)/$${f}; \
- 	done
+--- fd2sfd-1.0/Makefile.in	2003-07-31 08:10:19.000000000 +0200
++++ fd2sfd-1.0/Makefile.in	2014-03-05 12:09:10.000000000 +0100
+@@ -40,49 +40,13 @@
  
+ 	# Install tools
+ 	$(INSTALL_PROGRAM) $(EXECUTABLE) $(bindir)
+-	$(INSTALL_PROGRAM) cross/bin/gg-fix-includes $(bindir)
+-	for f in `cd $(srcdir)/cross/share/ && find * -type f`; do \
+-	  $(INSTALL_DATA) -D $(srcdir)/cross/share/$${f} $(fd2sfddir)/$${f}; \
+-	done
+-
 -	# Install example file structure for FDs
 -	$(INSTALL) -d $(prefix)/os-lib/fd/3rd
 -	$(INSTALL) -d $(prefix)/os-lib/fd/3rd-amigaos
@@ -32,7 +37,10 @@
 -		   prefs reaction resources rexx \
 -		   utility workbench; do \
 -	  $(INSTALL) -d $(prefix)/os-include/amigaos/$${dir}; \
--	done
++	$(INSTALL) -m 0755 cross/bin/gg-fix-includes $(bindir)
++	for d in `cd $(srcdir)/cross/share/ && find * -type d`; do \
++	  $(INSTALL) -d $(fd2sfddir)/$${d}; \
+ 	done
 -
 -	for dir in classes clib cybergraphx datatypes devices diskfont dos \
 -		   emul exec gadgets graphics guigfx hardware images \
@@ -40,9 +48,10 @@
 -		   prefs reaction render resources rexx \
 -		   utility workbench; do \
 -	  $(INSTALL) -d $(prefix)/os-include/morphos/$${dir}; \
--	done
++	for f in `cd $(srcdir)/cross/share/ && find * -type f`; do \
++	  $(INSTALL_DATA) $(srcdir)/cross/share/$${f} $(fd2sfddir)/$${f}; \
+ 	done
 -	$(INSTALL_DATA) $(srcdir)/README.os-include $(prefix)/os-include/README
--
+ 
  tgz:		all gg-fd2sfd.spec
  	cd $(srcdir) && cvs diff >/dev/null || (echo "Not checked in!"; exit 10)
- 	mkdir $(EXECUTABLE)-$(VERSION)

--- a/patches/gcc-2.95.3/include/libiberty.h.diff
+++ b/patches/gcc-2.95.3/include/libiberty.h.diff
@@ -9,4 +9,16 @@
 +
  /* Build an argument vector from a string.  Allocates memory using
     malloc.  Use freeargv to free the vector.  */
+
+@@ -111,11 +111,7 @@
  
+ /* Exit, calling all the functions registered with xatexit.  */
+ 
+-#ifndef __GNUC__
+-extern void xexit PARAMS ((int status));
+-#else
+-void xexit PARAMS ((int status)) __attribute__ ((noreturn));
+-#endif
++extern void xexit PARAMS ((int status)) __attribute__ ((__noreturn__));
+ 
+ /* Set the program name used by xmalloc.  */


### PR DESCRIPTION
Description of the fixes introduced:
- GCC 2.95.3 is now being compiled using -std=gnu89 flag. Otherwise the compilation fails during linking phase with "undefined symbols for architecture i386: _is_reserved_word"
- In binutils package, LLVM complained about multiple incompatible declarations of xexit(), failing with error. The declarations are now coherent for both binutils _and_ GCC and based on the GCC header file.
- fd2fsd used install -D option, which doesn't exist on BSD install. I replaced the appropriate block with separate find/install calls.
- build_libnix() now uses multi-core make call - performance improvement
