### PR TITLE
Patched the lexer to not re-define RETURN.

### DIFF
--- a/patches/gcc-2.95.3/gcc/c-lex.c.diff
+++ b/patches/gcc-2.95.3/gcc/c-lex.c.diff
@@ -1,0 +1,20 @@
+--- gcc-2.95.3/gcc/c-lex.c	2014-11-19 22:11:17.584287819 +0000
++++ gcc-2.95.3/gcc/c-lex.c	2014-11-19 22:12:36.079142782 +0000
+@@ -21,7 +21,6 @@
+ #include "config.h"
+ #include "system.h"
+ 
+-#include "rtl.h"
+ #include "tree.h"
+ #include "input.h"
+ #include "output.h"
+@@ -29,6 +28,9 @@
+ #include "c-tree.h"
+ #include "flags.h"
+ #include "c-parse.h"
++#ifndef RETURN
++#include "rtl.h"
++#endif
+ #include "c-pragma.h"
+ #include "toplev.h"
+ #include "intl.h"


### PR DESCRIPTION
Hi!

  The gcc-2.95.3 sources do not compile under gcc-4.4, the error given is the following:

In file included from m68k-amigaos-toolchain/sources/gcc-2.95.3/gcc/c-lex.c:31:
m68k-amigaos-toolchain/sources/gcc-2.95.3/gcc/c-parse.h:64:error: redeclaration of enumerator 'RETURN'
m68k-amigaos-toolchain/sources/gcc-2.95.3/gcc/rtl.def:503: note: previous definition of 'RETURN' was here

and stems from the fact that "RETURN" is defined twice from the files included by "c-lex.c":
- in "c-parse.h"
- from "rtl.h" and thereby "rtl.def"

which both contain a definition for "RETURN".

"c-lex.c" does not need "rtl.h" included (in fact, you can remove "rtl.h" entirely), however, to maintain the original source, I have created a patch that avoids the double-definition by inclusion of "rtl.h":

The patch is located at patches/gcc-2.95.3/gcc/c-lex.c.diff and refuses to include "rtl.h" in case it has already been defined by "c-parse.h":
# ifndef RETURN
# include "rtl.h"
# endif

If useful, please commit. Thanks.
