### PR TITLE
Guarantee 64-bit types

### DIFF
--- a/toolchain-m68k
+++ b/toolchain-m68k
@@ -117,8 +117,8 @@ def build_vbcc():
     'n', 'y', 'unsigned short',
     'n', 'y', 'signed int',
     'n', 'y', 'unsigned int',
-    'n', 'y', 'signed long',
-    'n', 'y', 'unsigned long',
+    'n', 'y', 'signed long long',
+    'n', 'y', 'unsigned long long',
     'n', 'y', 'float',
     'n', 'y', 'double')
   make('vbcc', TARGET='m68k', ETCDIR='\\"{target}/etc/\\"', CONFIG=config)


### PR DESCRIPTION
```
machines/m68k/machine.c: In function 'gen_dc':
machines/m68k/machine.c:3503:7: warning: right shift count >= width of type
       vumax=zumand(zumrshift(vumax,ul2zum(32UL)),ul2zum(0xffffffff));
       ^
```
With -std=c9x/gnu9x/c99 -m32, `long` will be a 32-bit type. Specify `long long` to guarantee 64-bit size and get rid of warnings like the above, and possible errors in the generated code.