### PR TITLE
fix issues running on 64 bit hosts:

### DIFF
--- a/common.py
+++ b/common.py
@@ -299,6 +299,14 @@ def add_site_dir(dirname):
   site.addsitedir(dirname)
 
 
+@fill_in_args
+def add_site_dir64(dirname):
+  dirname = path.join(dirname, 'lib64', 'python%d.%d' % sys.version_info[:2],
+                      'site-packages')
+  info('adding "%s" to python site dirs', topdir(dirname))
+  site.addsitedir(dirname)
+
+
 @contextlib.contextmanager
 def cwd(name):
   old = os.getcwd()
@@ -484,5 +492,5 @@ def require_header(header, lang, msg='', symbol=None, value=None):
 __all__ = ['setvar', 'panic', 'cmpver', 'find_executable', 'chmod', 'execute',
            'rmtree', 'mkdir', 'copy', 'copytree', 'unarc', 'fetch', 'cwd',
            'symlink', 'remove', 'move', 'find', 'textfile', 'env', 'path',
-           'add_site_dir', 'python_setup', 'recipe', 'unpack', 'patch',
-           'configure', 'make', 'require_header']
+           'add_site_dir', 'add_site_dir64', 'python_setup', 'recipe', 'unpack',
+           'patch', 'configure', 'make', 'require_header']

--- a/toolchain-m68k
+++ b/toolchain-m68k
@@ -206,6 +206,8 @@ def build():
       fetch(name, url)
 
   add_site_dir('{host}')
+  if platform.machine() == 'x86_64':
+    add_site_dir64('{host}')
 
   """
   Make sure we always choose known compiler (from the distro) and not one in
@@ -278,7 +280,8 @@ def build():
   make('{bison}', 'install')
 
   unpack('{texinfo}')
-  configure('{texinfo}', '--prefix={host}')
+  with env(CC=CC, CXX=CXX):
+    configure('{texinfo}', '--prefix={host}')
   make('{texinfo}')
   make('{texinfo}', 'install')
 
@@ -544,6 +547,8 @@ def install_sdk(*names):
                               environ['PATH']])
 
   add_site_dir('{host}')
+  if platform.machine() == 'x86_64':
+    add_site_dir64('{host}')
 
   for name in names:
     filename = path.join('{top}/sdk', name + '.sdk')

--- a/toolchain-ppc
+++ b/toolchain-ppc
@@ -70,6 +70,8 @@ def build():
                               environ['PATH']])
 
   add_site_dir('{host}')
+  if platform.machine() == 'x86_64':
+    add_site_dir64('{host}')
 
   with cwd('{archives}'):
     for url in URLS:


### PR DESCRIPTION
- run texinfo configury without -m32 added. otherwise, it requires
  the presence of 32 bit ncurses-devel. it may not be present, and
  it isn't necessary either.
- on 64 bit hosts, add another python sitedir with lib64 instead of
  just lib. don't know about debian and its alikes, but with fedora
  it installs itself under xxx/host/lib64, and lhafile import fails
  without the addition.