### PR TITLE
vclib: fix path of clib/Warp3D_protos.h

### DIFF
--- a/patches/vclib/targets/m68k-amigaos/include/proto/warp3d.h.diff
+++ b/patches/vclib/targets/m68k-amigaos/include/proto/warp3d.h.diff
@@ -1,0 +1,11 @@
+--- vclib/targets/m68k-amigaos/include/proto/warp3d.h~	2016-02-06 00:00:00.000000000 +0200
++++ vclib/targets/m68k-amigaos/include/proto/warp3d.h	2016-06-27 11:01:10.000000000 +0300
+@@ -5,7 +5,7 @@
+ #include <exec/types.h>
+ #endif
+ #if !defined(CLIB_WARP3D_PROTOS_H) && !defined(__GNUC__)
+-#include <clib/warp3d_protos.h>
++#include <clib/Warp3D_protos.h>
+ #endif
+ 
+ #ifndef __NOLIBBASE__

--- a/toolchain-m68k
+++ b/toolchain-m68k
@@ -315,6 +315,7 @@ def build():
   build_vbcc()
 
   unpack('vclib', top_dir='vbcc_target_m68k-amigaos')
+  patch('vclib')
 
   install_vbcc_toolchain()
 


### PR DESCRIPTION
I reported this to Frank Wille, and this is actually a fd2pragma issue:
http://eab.abime.net/showthread.php?t=84378
Until the day that is handled, this is a fair workaround.
