### PR TITLE
Integrate amitools into the toolchain

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,6 @@
 [submodule "submodules/binutils-2.14"]
 	path = submodules/binutils-2.14
 	url = https://github.com/adtools/amigaos-binutils-2.14.git
+[submodule "submodules/amitools"]
+	path = submodules/amitools
+	url = https://github.com/cnvogelg/amitools

--- a/.gitmodules
+++ b/.gitmodules
@@ -28,6 +28,3 @@
 [submodule "submodules/binutils-2.14"]
 	path = submodules/binutils-2.14
 	url = https://github.com/adtools/amigaos-binutils-2.14.git
-[submodule "submodules/amitools"]
-	path = submodules/amitools
-	url = https://github.com/cnvogelg/amitools

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Build process should produce following set of tools for **m68k-amigaos** target:
  * IRA: portable M68000/010/020/030/040 reassembler for AmigaOS hunk-format
    executables, libraries, devices and raw binary files
  * vda68k: portable M68k disassembler for 68000-68060, 68851, 68881, 68882
+ * [amitools](https://github.com/cnvogelg/amitools/blob/master/README.md#contents) with [vamos](https://github.com/cnvogelg/amitools/blob/master/doc/vamos.md) AmigaOS emulator which is proven to run SAS/C
 
 ... and following set of tools for **ppc-amigaos** target:
 

--- a/common.py
+++ b/common.py
@@ -397,7 +397,6 @@ def pysetup(name, **kwargs):
   prefix = kwargs.get('prefix', '{prefix}')
   with env(PYTHONPATH=extend_pythonpath(prefix)):
     with cwd(path.join('{build}', name)):
-      mkdir(SITEDIR)
       execute('{python}', 'setup.py', 'build')
       execute('{python}', 'setup.py', 'install', '--prefix=' + prefix)
 

--- a/common.py
+++ b/common.py
@@ -392,6 +392,12 @@ def pyinstall(name, **kwargs):
   with env(PYTHONPATH=extend_pythonpath(prefix)):
     execute('{python}', '-m', 'easy_install', '--prefix=' + prefix, name)
 
+@recipe('pyfixbin', 1)
+def pyfixbin(name, names, **kwargs):
+  prefix = kwargs.get('prefix', '{prefix}')
+  for name in names:
+    fix_python_shebang(path.join(prefix, 'bin', name), prefix)
+
 
 @recipe('pysetup', 1)
 def pysetup(name, **kwargs):
@@ -401,6 +407,15 @@ def pysetup(name, **kwargs):
     with cwd(path.join('{build}', name)):
       execute('{python}', 'setup.py', 'build')
       execute('{python}', 'setup.py', 'install', '--prefix=' + prefix)
+
+
+@recipe('pypip', 1)
+def pypip(name, **kwargs):
+  prefix = kwargs.get('prefix', '{prefix}')
+  mkdir(path.join(prefix, '{sitedir}'))
+  with env(PYTHONPATH=extend_pythonpath(prefix)):
+    with cwd(path.join('{build}', name)):
+      execute('pip', 'install', '--prefix=' + prefix, name)
 
 
 @recipe('fetch', 1)
@@ -534,4 +549,4 @@ __all__ = ['setvar', 'panic', 'cmpver', 'find_executable', 'chmod', 'execute',
            'symlink', 'remove', 'move', 'find', 'textfile', 'env', 'path',
            'add_site_dir', 'find_site_dir', 'pysetup', 'pyinstall', 'recipe',
            'unpack', 'patch', 'configure', 'make', 'require_header', 'touch',
-           'fix_python_shebang']
+           'pypip', 'pyfixbin']

--- a/common.py
+++ b/common.py
@@ -409,15 +409,6 @@ def pysetup(name, **kwargs):
       execute('{python}', 'setup.py', 'install', '--prefix=' + prefix)
 
 
-@recipe('pypip', 1)
-def pypip(name, **kwargs):
-  prefix = kwargs.get('prefix', '{prefix}')
-  mkdir(path.join(prefix, '{sitedir}'))
-  with env(PYTHONPATH=extend_pythonpath(prefix)):
-    with cwd(path.join('{build}', name)):
-      execute('pip', 'install', '--prefix=' + prefix, name)
-
-
 @recipe('fetch', 1)
 def fetch(name, url):
   if url.startswith('http') or url.startswith('ftp'):
@@ -549,4 +540,4 @@ __all__ = ['setvar', 'panic', 'cmpver', 'find_executable', 'chmod', 'execute',
            'symlink', 'remove', 'move', 'find', 'textfile', 'env', 'path',
            'add_site_dir', 'find_site_dir', 'pysetup', 'pyinstall', 'recipe',
            'unpack', 'patch', 'configure', 'make', 'require_header', 'touch',
-           'pypip', 'pyfixbin']
+           'pyfixbin']

--- a/common.py
+++ b/common.py
@@ -380,7 +380,7 @@ def recipe(name, nargs=0):
 def extend_pythonpath(prefix):
   SITEDIR = path.join(prefix, '{sitedir}')
   try:
-    return ':'.join(os.environ['PYTHONPATH'], SITEDIR)
+    return ':'.join([os.environ['PYTHONPATH'], SITEDIR])
   except KeyError:
     return SITEDIR
 
@@ -388,6 +388,7 @@ def extend_pythonpath(prefix):
 @recipe('pyinstall', 1)
 def pyinstall(name, **kwargs):
   prefix = kwargs.get('prefix', '{prefix}')
+  mkdir(path.join(prefix, '{sitedir}'))
   with env(PYTHONPATH=extend_pythonpath(prefix)):
     execute('{python}', '-m', 'easy_install', '--prefix=' + prefix, name)
 
@@ -395,6 +396,7 @@ def pyinstall(name, **kwargs):
 @recipe('pysetup', 1)
 def pysetup(name, **kwargs):
   prefix = kwargs.get('prefix', '{prefix}')
+  mkdir(path.join(prefix, '{sitedir}'))
   with env(PYTHONPATH=extend_pythonpath(prefix)):
     with cwd(path.join('{build}', name)):
       execute('{python}', 'setup.py', 'build')

--- a/common.py
+++ b/common.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python2.7 -B
 
+from __future__ import print_function
+
 from fnmatch import fnmatch
 from glob import glob
 from logging import debug, info, error
 from os import path
 import contextlib
 from distutils import spawn, sysconfig
+import fileinput
 import os
 import shutil
 import site
@@ -260,7 +263,7 @@ def download(url, name):
       sys.stdout.write(status)
       sys.stdout.flush()
 
-  print ""
+  print("")
 
 
 @fill_in_args
@@ -290,6 +293,18 @@ def unarc(name):
         arc.extract(item)
   else:
     raise RuntimeError('Unrecognized archive: "%s"', name)
+
+
+@fill_in_args
+def fix_python_shebang(filename, prefix):
+  PYTHON = fill_in('{python}')
+  SITEDIR = path.join(prefix, '{sitedir}')
+  for line in fileinput.input(files=[filename], inplace=True):
+    line = line.rstrip()
+    if line.startswith('#!'):
+      print('#!/usr/bin/env PYTHONPATH=%s %s' % (SITEDIR, PYTHON))
+    else:
+      print(line.rstrip())
 
 
 @fill_in_args
@@ -362,12 +377,29 @@ def recipe(name, nargs=0):
   return real_decorator
 
 
-@recipe('python-setup', 1)
-def python_setup(name, **kwargs):
-  dest_dir = kwargs.get('dest_dir', '{host}')
-  with cwd(path.join('{build}', name)):
-    execute(sys.executable, 'setup.py', 'build')
-    execute(sys.executable, 'setup.py', 'install', '--prefix=' + dest_dir)
+def extend_pythonpath(prefix):
+  SITEDIR = path.join(prefix, '{sitedir}')
+  try:
+    return ':'.join(os.environ['PYTHONPATH'], SITEDIR)
+  except KeyError:
+    return SITEDIR
+
+
+@recipe('pyinstall', 1)
+def pyinstall(name, **kwargs):
+  prefix = kwargs.get('prefix', '{prefix}')
+  with env(PYTHONPATH=extend_pythonpath(prefix)):
+    execute('{python}', '-m', 'easy_install', '--prefix=' + prefix, name)
+
+
+@recipe('pysetup', 1)
+def pysetup(name, **kwargs):
+  prefix = kwargs.get('prefix', '{prefix}')
+  with env(PYTHONPATH=extend_pythonpath(prefix)):
+    with cwd(path.join('{build}', name)):
+      mkdir(SITEDIR)
+      execute('{python}', 'setup.py', 'build')
+      execute('{python}', 'setup.py', 'install', '--prefix=' + prefix)
 
 
 @recipe('fetch', 1)
@@ -499,5 +531,6 @@ def require_header(headers, lang='c', errmsg='', symbol=None, value=None):
 __all__ = ['setvar', 'panic', 'cmpver', 'find_executable', 'chmod', 'execute',
            'rmtree', 'mkdir', 'copy', 'copytree', 'unarc', 'fetch', 'cwd',
            'symlink', 'remove', 'move', 'find', 'textfile', 'env', 'path',
-           'add_site_dir', 'find_site_dir', 'python_setup', 'recipe',
-           'unpack', 'patch', 'configure', 'make', 'require_header', 'touch']
+           'add_site_dir', 'find_site_dir', 'pysetup', 'pyinstall', 'recipe',
+           'unpack', 'patch', 'configure', 'make', 'require_header', 'touch',
+           'fix_python_shebang']

--- a/toolchain-m68k
+++ b/toolchain-m68k
@@ -32,7 +32,7 @@ URLS = \
    'http://sun.hasenbraten.de/vasm/release/vasm.tar.gz',
    'http://sun.hasenbraten.de/vlink/release/vlink.tar.gz',
    ('http://server.owl.de/~frank/tags/vbcc0_9f.tar.gz', 'vbcc.tar.gz'),
-   'http://aminet.net/dev/asm/ira.lha',
+   'http://de3.aminet.net/dev/asm/ira.lha',
    'http://sun.hasenbraten.de/~frank/projects/download/vdam68k.tar.gz',
    ('http://mail.pb-owl.de/~frank/vbcc/current/vbcc_target_m68k-amigaos.lha',
     'vclib.lha')]

--- a/toolchain-m68k
+++ b/toolchain-m68k
@@ -525,12 +525,8 @@ def build():
 
   install_tools()
 
-  pyinstall('cython', prefix='{host}')
-  fix_cython()
-
   unpack('amitools', work_dir='{build}')
-  with env(PYTHONPATH=path.join('{host}', '{sitedir}')):
-    pysetup('amitools')
+  pysetup('amitools')
   fix_amitools()
 
 

--- a/toolchain-m68k
+++ b/toolchain-m68k
@@ -118,23 +118,6 @@ def install_tools():
   copy('{build}/vdam68k/vda68k', '{prefix}/bin')
 
 
-@recipe('cython-fix')
-def fix_cython():
-  info('fixing cython')
-
-  for script in ['cygdb', 'cython', 'cythonize']:
-    fix_python_shebang(path.join('{host}', 'bin', script), '{host}')
-
-
-@recipe('amitools-fix')
-def fix_amitools():
-  info('fixing amitools')
-
-  for tool in ['fdtool', 'geotool', 'hunktool', 'rdbtool', 'romtool',
-          'typetool', 'vamos', 'vamospath', 'xdfscan', 'xdftool']:
-    fix_python_shebang(path.join('{prefix}', 'bin', tool), '{prefix}')
-
-
 @recipe('{libamiga}-install')
 def install_libamiga():
   info('installing libamiga')
@@ -334,8 +317,11 @@ def build():
   py_ver = 'python%d.%d' % (sys.version_info.major, sys.version_info.minor)
   require_header([path.join(py_ver, 'Python.h')],
                  lang='c', errmsg='python-dev package missing')
+  pyinstall('pip', prefix='{host}')
+  pyfixbin('pip', ['pip'], prefix='{host}')
+
   unpack('python-lha', work_dir='{build}')
-  pysetup('python-lha', prefix='{prefix}')
+  pysetup('python-lha')
 
   unpack('{m4}')
   configure('{m4}', '--prefix={host}')
@@ -525,9 +511,9 @@ def build():
 
   install_tools()
 
-  unpack('amitools', work_dir='{build}')
-  pysetup('amitools')
-  fix_amitools()
+  pypip('amitools')
+  pyfixbin('amitools', ['fdtool', 'geotool', 'hunktool', 'rdbtool', 'romtool',
+                        'typetool', 'vamos', 'vamospath', 'xdfscan', 'xdftool'])
 
 
 def clean():

--- a/toolchain-m68k
+++ b/toolchain-m68k
@@ -132,7 +132,7 @@ def fix_amitools():
 
   for tool in ['fdtool', 'geotool', 'hunktool', 'rdbtool', 'romtool',
           'typetool', 'vamos', 'vamospath', 'xdfscan', 'xdftool']:
-    fix_python_shebang('{prefix}/bin/' + tool, '{prefix}')
+    fix_python_shebang(path.join('{prefix}', 'bin', tool), '{prefix}')
 
 
 @recipe('{libamiga}-install')
@@ -283,7 +283,7 @@ def build():
   execute('git', 'submodule', 'init');
   execute('git', 'submodule', 'update');
 
-  add_site_dir('{host}')
+  add_site_dir('{prefix}')
 
   """
   Make sure we always choose known compiler (from the distro) and not one in
@@ -525,11 +525,12 @@ def build():
 
   install_tools()
 
-  pyinstall('cython')
+  pyinstall('cython', prefix='{host}')
   fix_cython()
 
   unpack('amitools', work_dir='{build}')
-  pysetup('amitools')
+  with env(PYTHONPATH=path.join('{host}', '{sitedir}')):
+    pysetup('amitools')
   fix_amitools()
 
 

--- a/toolchain-m68k
+++ b/toolchain-m68k
@@ -312,16 +312,18 @@ def build():
   require_header(['ncurses.h', 'ncurses/ncurses.h'],
                  lang='c', errmsg='libncurses-dev package missing')
 
-  unpack('{automake}')
-
   py_ver = 'python%d.%d' % (sys.version_info.major, sys.version_info.minor)
   require_header([path.join(py_ver, 'Python.h')],
                  lang='c', errmsg='python-dev package missing')
-  pyinstall('pip', prefix='{host}')
-  pyfixbin('pip', ['pip'], prefix='{host}')
 
   unpack('python-lha', work_dir='{build}')
   pysetup('python-lha')
+
+  pyinstall('amitools')
+  pyfixbin('amitools', ['fdtool', 'geotool', 'hunktool', 'rdbtool', 'romtool',
+                        'typetool', 'vamos', 'vamospath', 'xdfscan', 'xdftool'])
+
+  unpack('{automake}')
 
   unpack('{m4}')
   configure('{m4}', '--prefix={host}')
@@ -510,10 +512,6 @@ def build():
   make('vdam68k')
 
   install_tools()
-
-  pypip('amitools')
-  pyfixbin('amitools', ['fdtool', 'geotool', 'hunktool', 'rdbtool', 'romtool',
-                        'typetool', 'vamos', 'vamospath', 'xdfscan', 'xdftool'])
 
 
 def clean():

--- a/toolchain-m68k
+++ b/toolchain-m68k
@@ -319,10 +319,6 @@ def build():
   unpack('python-lha', work_dir='{build}')
   pysetup('python-lha')
 
-  pyinstall('amitools')
-  pyfixbin('amitools', ['fdtool', 'geotool', 'hunktool', 'rdbtool', 'romtool',
-                        'typetool', 'vamos', 'vamospath', 'xdfscan', 'xdftool'])
-
   unpack('{automake}')
 
   unpack('{m4}')
@@ -512,6 +508,10 @@ def build():
   make('vdam68k')
 
   install_tools()
+
+  pyinstall('amitools')
+  pyfixbin('amitools', ['fdtool', 'geotool', 'hunktool', 'rdbtool', 'romtool',
+                        'typetool', 'vamos', 'vamospath', 'xdfscan', 'xdftool'])
 
 
 def clean():

--- a/toolchain-m68k
+++ b/toolchain-m68k
@@ -118,6 +118,23 @@ def install_tools():
   copy('{build}/vdam68k/vda68k', '{prefix}/bin')
 
 
+@recipe('cython-fix')
+def fix_cython():
+  info('fixing cython')
+
+  for script in ['cygdb', 'cython', 'cythonize']:
+    fix_python_shebang(path.join('{host}', 'bin', script), '{host}')
+
+
+@recipe('amitools-fix')
+def fix_amitools():
+  info('fixing amitools')
+
+  for tool in ['fdtool', 'geotool', 'hunktool', 'rdbtool', 'romtool',
+          'typetool', 'vamos', 'vamospath', 'xdfscan', 'xdftool']:
+    fix_python_shebang('{prefix}/bin/' + tool, '{prefix}')
+
+
 @recipe('{libamiga}-install')
 def install_libamiga():
   info('installing libamiga')
@@ -318,7 +335,7 @@ def build():
   require_header([path.join(py_ver, 'Python.h')],
                  lang='c', errmsg='python-dev package missing')
   unpack('python-lha', work_dir='{build}')
-  python_setup('python-lha')
+  pysetup('python-lha', prefix='{prefix}')
 
   unpack('{m4}')
   configure('{m4}', '--prefix={host}')
@@ -508,6 +525,13 @@ def build():
 
   install_tools()
 
+  pyinstall('cython')
+  fix_cython()
+
+  unpack('amitools', work_dir='{build}')
+  pysetup('amitools')
+  fix_amitools()
+
 
 def clean():
   rmtree('{stamps}')
@@ -654,7 +678,7 @@ def install_sdk(*names):
                               path.join('{host}', 'bin'),
                               environ['PATH']])
 
-  add_site_dir('{host}')
+  add_site_dir('{prefix}')
 
   with cwd('{prefix}/{target}'):
     mkdir('doc', 'guide', 'include/proto', 'include/inline', 'include/lvo',
@@ -727,7 +751,8 @@ if __name__ == "__main__":
 
   setvar(top=path.abspath(path.dirname(sys.argv[0])),
          binutils_ver=args.binutils,
-         gcc_ver=args.gcc)
+         gcc_ver=args.gcc,
+         py_ver='python%d.%d' % (sys.version_info.major, sys.version_info.minor))
 
   setvar(m4='m4-1.4.17',
          gawk='gawk-3.1.8',
@@ -747,6 +772,8 @@ if __name__ == "__main__":
          gcc='gcc-{gcc_ver}',
          gpp='g++-{gcc_ver}',
          target='m68k-amigaos',
+         python=sys.executable,
+         sitedir=path.join('lib', '{py_ver}', 'site-packages'),
          patches=path.join('{top}', 'patches'),
          stamps=path.join('{top}', '.build-m68k', 'stamps'),
          build=path.join('{top}', '.build-m68k', 'build'),


### PR DESCRIPTION
This change adds all constituents of [amitools](https://github.com/cnvogelg/amitools) package to toolchain installation prefix.

@cnvogelg Before I merge this change I'd like to solve, with your help, several issues I have with the integration process, namely:

* In order to generate Python-to-C bindings (for Musashi), user is forced to install `cython` package. Cython takes much more time to compile compared to amitools. IMO it's not well justified to force bindings regeneration during user builds, though it's perfectly ok to run `cython` while performing developer build. Could you distribute generated sources for bindings?
* By default installation process does not require `fd` files. User learns that hard way after trying to run `vamos`. Could you require from user to give path to `fd` directory during installation?
```
12:17:06.759     libmgr:  ERROR:  [create_lib] can't create auto lib without FD file: exec.library
12:17:06.759     libmgr:  ERROR:  [create_lib] can't create auto lib without FD file: dos.library
```
