### PR TITLE
Fix toolchain-ppc

### DIFF
--- a/common.py
+++ b/common.py
@@ -412,17 +412,13 @@ def pysetup(name, **kwargs):
 
 @recipe('fetch', 1)
 def fetch(name, url):
-  if url.startswith('http') or url.startswith('ftp'):
+  if 'svn' in url:
+    execute('svn', 'export', url, name)
+  elif url.startswith('http') or url.startswith('ftp'):
     if not path.exists(name):
       download(url, name)
     else:
       info('File "%s" already downloaded.', name)
-  elif url.startswith('svn'):
-    if not path.exists(name):
-      execute('svn', 'checkout', url, name)
-    else:
-      with cwd(name):
-        execute('svn', 'update')
   elif url.startswith('git'):
     if not path.exists(name):
       execute('git', 'clone', url, name)

--- a/common.py
+++ b/common.py
@@ -9,6 +9,7 @@ from os import path
 import contextlib
 from distutils import spawn, sysconfig
 import fileinput
+import multiprocessing
 import os
 import shutil
 import site
@@ -502,6 +503,7 @@ def make(name, target=None, makefile=None, **makevars):
       args = [target] + args
     if makefile is not None:
       args = ['-f', makefile] + args
+    args = ['-j%d' % multiprocessing.cpu_count()] + args
     execute('make', *args)
 
 

--- a/toolchain-ppc
+++ b/toolchain-ppc
@@ -58,6 +58,10 @@ def fetch_all():
         url, name = url[0], url[1]
       else:
         name = path.basename(url)
+      if 'gcc' in name and args.gcc not in name:
+        continue
+      if 'binutils' in name and args.binutils not in name:
+        continue
       fetch(name, url)
 
 

--- a/toolchain-ppc
+++ b/toolchain-ppc
@@ -41,7 +41,7 @@ def update_autotools(dst):
 def prepare_sdk():
   info('preparing {sdk}')
 
-  target = path.join('{target}', 'ppc-amigaos/SDK')
+  target = path.join('{prefix}', 'ppc-amigaos/SDK')
 
   unpack('{sdk}', work_dir='{archives}', top_dir='SDK_Install', dst_dir='SDK')
   unpack('SDK/base', top_dir='Include', dst_dir=path.join(target, 'include'))
@@ -72,7 +72,7 @@ def build():
   find_executable('make')
   find_executable('svn')
 
-  environ['PATH'] = ":".join([path.join('{target}', 'bin'),
+  environ['PATH'] = ":".join([path.join('{prefix}', 'bin'),
                               path.join('{host}', 'bin'),
                               environ['PATH']])
 
@@ -150,7 +150,7 @@ def build():
   with env(CFLAGS='-Wno-error'):
     update_autotools('{archives}/{binutils}')
     configure('{binutils}',
-              '--prefix={target}',
+              '--prefix={prefix}',
               '--target=ppc-amigaos',
               from_dir='{archives}/{binutils}')
     make('{binutils}')
@@ -167,7 +167,7 @@ def build():
   update_autotools('{archives}/{gcc}')
   with env(**gcc_env):
     configure('{gcc}',
-              '--prefix={target}',
+              '--prefix={prefix}',
               '--target=ppc-amigaos',
               '--with-bugurl="http://sf.net/p/adtools"',
               '--with-gmp={host}',
@@ -221,7 +221,8 @@ if __name__ == "__main__":
 
   setvar(top=path.abspath(path.dirname(sys.argv[0])),
          binutils_ver=args.binutils,
-         gcc_ver=args.gcc)
+         gcc_ver=args.gcc,
+         py_ver='python%d.%d' % (sys.version_info.major, sys.version_info.minor))
 
   setvar(gmp='gmp-5.1.3',
          mpfr='mpfr-3.1.3',
@@ -233,21 +234,23 @@ if __name__ == "__main__":
          binutils='binutils-{binutils_ver}',
          sdk='SDK_53.24',
          gcc='gcc-{gcc_ver}',
+         python=sys.executable,
+         sitedir=path.join('lib', '{py_ver}', 'site-packages'),
          patches=path.join('{top}', 'patches'),
          stamps=path.join('{top}', '.build-ppc', 'stamps'),
          build=path.join('{top}', '.build-ppc', 'build'),
          sources=path.join('{top}', '.build-ppc', 'sources'),
          host=path.join('{top}', '.build-ppc', 'host'),
          tmpdir=path.join('{top}', '.build-ppc', 'tmpdir'),
-         target=path.join('{top}', 'ppc-amigaos'),
+         prefix=path.join('{top}', 'ppc-amigaos'),
          archives=path.join('{top}', '.build-ppc', 'archives'),
          submodules=path.join('{top}', 'submodules'))
 
   if args.prefix is not None:
-    setvar(target=args.prefix)
+    setvar(prefix=args.prefix)
 
-  if not path.exists('{target}'):
-    mkdir('{target}')
+  if not path.exists('{prefix}'):
+    mkdir('{prefix}')
 
   action = args.action.replace('-', '_')
   globals()[action].__call__(*args.args)

--- a/toolchain-ppc
+++ b/toolchain-ppc
@@ -48,6 +48,7 @@ def prepare_sdk():
   unpack('SDK/base', top_dir='Include', dst_dir=path.join(target, 'include'))
   unpack('SDK/clib2', top_dir='clib2', dst_dir=path.join(target, 'clib2'))
   unpack('SDK/newlib', top_dir='newlib', dst_dir=path.join(target, 'newlib'))
+  unpack('SDK/pthread', top_dir='Local', dst_dir=target)
 
 
 def build():

--- a/toolchain-ppc
+++ b/toolchain-ppc
@@ -51,6 +51,16 @@ def prepare_sdk():
   unpack('SDK/pthread', top_dir='Local', dst_dir=target)
 
 
+def fetch_all():
+  with cwd('{archives}'):
+    for url in URLS:
+      if type(url) == tuple:
+        url, name = url[0], url[1]
+      else:
+        name = path.basename(url)
+      fetch(name, url)
+
+
 def build():
   for var in environ.keys():
     if var not in ['_', 'LOGNAME', 'HOME', 'SHELL', 'TMPDIR', 'PWD']:
@@ -80,13 +90,7 @@ def build():
 
   add_site_dir('{host}')
 
-  with cwd('{archives}'):
-    for url in URLS:
-      if type(url) == tuple:
-        url, name = url[0], url[1]
-      else:
-        name = path.basename(url)
-      fetch(name, url)
+  fetch_all()
 
   require_header(['ncurses.h', 'ncurses/ncurses.h'],
                  lang='c', errmsg='libncurses-dev package missing')
@@ -212,7 +216,7 @@ if __name__ == "__main__":
 
   parser = argparse.ArgumentParser(description='Build cross toolchain.')
   parser.add_argument('action',
-                      choices=['build', 'clean'],
+                      choices=['build', 'clean', 'fetch-all'],
                       default='build', help='perform action')
   parser.add_argument('args', metavar='ARGS', type=str, nargs='*',
                       help='action arguments')

--- a/toolchain-ppc
+++ b/toolchain-ppc
@@ -88,13 +88,16 @@ def build():
         name = path.basename(url)
       fetch(name, url)
 
-  unpack('{automake}')
+  require_header(['ncurses.h', 'ncurses/ncurses.h'],
+                 lang='c', errmsg='libncurses-dev package missing')
 
   py_ver = 'python%d.%d' % (sys.version_info.major, sys.version_info.minor)
   require_header([path.join(py_ver, 'Python.h')],
                  lang='c', errmsg='python-dev package missing')
   unpack('{python_lhafile}', work_dir='{build}')
   pysetup('{python_lhafile}', prefix='/usr/local')
+
+  unpack('{automake}')
 
   unpack('{texinfo}')
   update_autotools('{sources}/{texinfo}/build-aux')

--- a/toolchain-ppc
+++ b/toolchain-ppc
@@ -11,21 +11,22 @@ import platform
 import sys
 
 URLS = \
-  ['git://github.com/FrodeSolheim/python-lhafile',
-   'ftp://ftp.gnu.org/gnu/gmp/gmp-5.1.3.tar.bz2',
-   'ftp://ftp.gnu.org/gnu/mpc/mpc-1.0.3.tar.gz',
-   'ftp://ftp.gnu.org/gnu/mpfr/mpfr-3.1.3.tar.bz2',
-   'ftp://ftp.gnu.org/gnu/texinfo/texinfo-4.12.tar.gz',
+  [('https://github.com/FrodeSolheim/python-lhafile/archive/v0.2.2.tar.gz',
+    'python-lhafile-0.2.2.tar.gz'),
+   'https://ftp.gnu.org/gnu/gmp/gmp-5.1.3.tar.bz2',
+   'https://ftp.gnu.org/gnu/mpc/mpc-1.0.3.tar.gz',
+   'https://ftp.gnu.org/gnu/mpfr/mpfr-3.1.3.tar.bz2',
+   'https://ftp.gnu.org/gnu/texinfo/texinfo-4.12.tar.gz',
    'http://isl.gforge.inria.fr/isl-0.12.2.tar.bz2',
-   'http://www.bastoul.net/cloog/pages/download/cloog-0.18.4.tar.gz',
-   'ftp://ftp.gnu.org/gnu/automake/automake-1.15.tar.gz',
-   ('http://hyperion-entertainment.biz/index.php/downloads' +
-    '?view=download&amp;format=raw&amp;file=69', 'SDK_53.24.lha'),
-   ('svn://svn.code.sf.net/p/adtools/code/trunk/binutils', 'binutils-2.18'),
-   ('svn://svn.code.sf.net/p/adtools/code/trunk/gcc', 'gcc-4.2.4'),
-   ('svn://svn.code.sf.net/p/adtools/code/branches/binutils/2.23.2',
+   'https://www.bastoul.net/cloog/pages/download/cloog-0.18.4.tar.gz',
+   'https://ftp.gnu.org/gnu/automake/automake-1.15.tar.gz',
+   ('http://hyperion-entertainment.biz/index.php/downloads'
+    '?view=download&format=raw&file=69', 'SDK_53.24.lha'),
+   ('https://svn.code.sf.net/p/adtools/code/trunk/binutils', 'binutils-2.18'),
+   ('https://svn.code.sf.net/p/adtools/code/trunk/gcc', 'gcc-4.2.4'),
+   ('https://svn.code.sf.net/p/adtools/code/branches/binutils/2.23.2',
     'binutils-2.23.2'),
-   ('svn://svn.code.sf.net/p/adtools/code/branches/gcc/4.9.x', 'gcc-4.9.1')]
+   ('https://svn.code.sf.net/p/adtools/code/branches/gcc/4.9.x', 'gcc-4.9.1')]
 
 
 from common import * # NOQA
@@ -91,8 +92,8 @@ def build():
   py_ver = 'python%d.%d' % (sys.version_info.major, sys.version_info.minor)
   require_header([path.join(py_ver, 'Python.h')],
                  lang='c', errmsg='python-dev package missing')
-  unpack('python-lha', work_dir='{build}')
-  python_setup('python-lha')
+  unpack('{python_lhafile}', work_dir='{build}')
+  pysetup('{python_lhafile}', prefix='/usr/local')
 
   unpack('{texinfo}')
   update_autotools('{sources}/{texinfo}/build-aux')
@@ -232,6 +233,7 @@ if __name__ == "__main__":
          texinfo='texinfo-4.12',
          automake='automake-1.15',
          binutils='binutils-{binutils_ver}',
+         python_lhafile='python-lhafile-0.2.2',
          sdk='SDK_53.24',
          gcc='gcc-{gcc_ver}',
          python=sys.executable,


### PR DESCRIPTION
toolchain-ppc has been broken for a while; this changeset gets it working again. There are some changes here that probably need to be applied to toolchain-m68k as well, like changing the ftp URLs to https for gnu.org since [that service is being turned off](https://ftp.gnu.org/CRYPTO.README), but I did not make these changes since I don’t have any use for a GCC2 compiler.